### PR TITLE
Bugfix/ssl accept error

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 
-{deps, [{director, "17.9.10"}]}.
+{deps, [{director, "17.9.11"}]}.
 
 
 {dialyzer

--- a/src/sockerl_ssl_transporter.erl
+++ b/src/sockerl_ssl_transporter.erl
@@ -108,7 +108,7 @@ accept(ListenSock, Opts) ->
     {ATimeout, HTimeout} = get_accept_and_handshake_timeout(Opts),
     case catch ssl:transport_accept(ListenSock, ATimeout) of
         {ok, Sock} ->
-            case catch ssl:ssl_accept(Sock, HTimeout) of
+            case catch ssl:handshake(Sock, HTimeout) of
                 ok ->
                     {ok, Sock};
                 {error, Reason} ->


### PR DESCRIPTION
Fix compile error Erlang 21, erts 10.0.1 
src/sockerl_ssl_transporter.erl:111: ssl:ssl_accept/2: deprecated; use ssl:handshake/2 instead

